### PR TITLE
商品削除機能_実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user! , only: [:new, :edit]
+  before_action :authenticate_user! , only: [:new, :edit, :destroy]
   before_action :set_item, only: [:edit, :show ,:update, :destroy]
   before_action :move_to_index, only: [:edit, :destroy]
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,7 +37,6 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    binding.pry
     @item.destroy
     redirect_to root_path
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user! , only: [:new, :edit]
-  before_action :set_item, only: [:edit, :show ,:update]
-  before_action :move_to_index, only: [:edit]
+  before_action :set_item, only: [:edit, :show ,:update, :destroy]
+  before_action :move_to_index, only: [:edit, :destroy]
 
   def index
     @items = Item.all.order(created_at: :desc)
@@ -34,6 +34,12 @@ class ItemsController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    binding.pry
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
       <% if current_user == @item.user %>
         <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item.id), data: {turbo_method: :delete}, class:"item-destroy" %>
       <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>


### PR DESCRIPTION
# What
商品削除機能の実装

# Why
ユーザーが自分が出品した商品の商品情報を削除できるようにするため

〇ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
・ログインしていて自分が出品した商品の場合は削除できる
https://gyazo.com/20307a46fb713718891477e2a091c2da

・ログアウト時は「削除」ボタンが表示されない
https://gyazo.com/c41ca33963fff8c264e0118f6e6c3ffe

・ログインしていても自分以外のユーザーの商品の場合は「削除」ボタンが表示されない
https://gyazo.com/9b4127fece9a265e31c02bde8affdc96

※テスト時に書いたbinding.pryが入ったままだったので「商品削除機能_itemコントローラー内のbinding.pryを削除」プルリクエストで削除しました。
